### PR TITLE
Add option to skip Cursor IDE install

### DIFF
--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -7,6 +7,12 @@ source ./scripts/utils.sh
 step "Installing Homebrew packages from configs/Brewfile"
 echo ""
 echo "--------------------------------------------------------"
-brew bundle --file=configs/Brewfile
+if [ "$INSTALL_CURSOR" = "false" ]; then
+  grep -v '^cask "cursor"$' configs/Brewfile > /tmp/OmakosBrewfile
+  brew bundle --file=/tmp/OmakosBrewfile
+  rm /tmp/OmakosBrewfile
+else
+  brew bundle --file=configs/Brewfile
+fi
 echo "--------------------------------------------------------"
 print_success "Homebrew packages installed!"

--- a/setup.sh
+++ b/setup.sh
@@ -42,7 +42,8 @@ check_internet_connection
 ###############################################################################
 # OPTION: Install Cursor IDE
 ###############################################################################
-if ask "Would you like to install Cursor IDE?" Y; then
+read -p "Would you like to install Cursor IDE? (y/n): " answer
+if [[ "$answer" =~ ^[Yy]$ ]]; then
   INSTALL_CURSOR=true
 else
   INSTALL_CURSOR=false

--- a/setup.sh
+++ b/setup.sh
@@ -40,6 +40,16 @@ chapter "Checking internet connection…"
 check_internet_connection
 
 ###############################################################################
+# OPTION: Install Cursor IDE
+###############################################################################
+if ask "Would you like to install Cursor IDE?" Y; then
+  INSTALL_CURSOR=true
+else
+  INSTALL_CURSOR=false
+fi
+export INSTALL_CURSOR
+
+###############################################################################
 # PROMPT: Password
 ###############################################################################
 chapter "Caching password…"
@@ -106,8 +116,10 @@ source ./scripts/zsh_setup.sh
 ###############################################################################
 # SETUP: Cursor
 ###############################################################################
-chapter "Setting up Cursor…"
-source ./scripts/cursor_setup.sh
+if [ "$INSTALL_CURSOR" = "true" ]; then
+  chapter "Setting up Cursor…"
+  source ./scripts/cursor_setup.sh
+fi
 
 ###############################################################################
 # SETUP: Git


### PR DESCRIPTION
## Summary
- allow skipping Cursor IDE install in setup
- respect choice in Homebrew install

## Testing
- `bash -n setup.sh`
- `bash -n scripts/brew.sh`


------
https://chatgpt.com/codex/tasks/task_e_688be52d93c883249f97aa68a08d5e3d