### PR TITLE
Add option to skip Cursor IDE install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Run this single command in your terminal:
 ```sh
 curl -L https://raw.githubusercontent.com/yatish27/omakos/main/install.sh | bash
 ```
+During setup you'll be asked whether to install [Cursor IDE](https://cursor.sh/).
+Choose "n" to skip it if you prefer another editor.
 
 ### Option 2: Manual Install
 
@@ -191,6 +193,7 @@ The script is designed to be customizable. You can:
 - Modify the [`Brewfile`](configs/Brewfile) to add/remove packages
 - Adjust macOS settings in [`scripts/mac_setup.sh`](scripts/mac_setup.sh)
 - Modify the dotfiles in [`configs/`](configs/) directory
+- Skip Cursor IDE by setting `INSTALL_CURSOR=false` or choosing "n" when prompted
 
 ## Contributing
 

--- a/install.sh
+++ b/install.sh
@@ -46,3 +46,4 @@ echo -e "${BLUE}Starting setup...${NC}
 
 # Run setup script
 ./setup.sh
+

--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -7,6 +7,12 @@ source ./scripts/utils.sh
 step "Installing Homebrew packages from configs/Brewfile"
 echo ""
 echo "--------------------------------------------------------"
-brew bundle --file=configs/Brewfile
+if [ "$INSTALL_CURSOR" = "false" ]; then
+  grep -v '^cask "cursor"$' configs/Brewfile > /tmp/OmakosBrewfile
+  brew bundle --file=/tmp/OmakosBrewfile
+  rm /tmp/OmakosBrewfile
+else
+  brew bundle --file=configs/Brewfile
+fi
 echo "--------------------------------------------------------"
 print_success "Homebrew packages installed!"

--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -16,3 +16,4 @@ else
 fi
 echo "--------------------------------------------------------"
 print_success "Homebrew packages installed!"
+

--- a/scripts/cursor_setup.sh
+++ b/scripts/cursor_setup.sh
@@ -48,3 +48,4 @@ else
 fi
 
 print_success "Cursor setup completed!"
+

--- a/setup.sh
+++ b/setup.sh
@@ -40,6 +40,16 @@ chapter "Checking internet connection…"
 check_internet_connection
 
 ###############################################################################
+# OPTION: Install Cursor IDE
+###############################################################################
+if ask "Would you like to install Cursor IDE?" Y; then
+  INSTALL_CURSOR=true
+else
+  INSTALL_CURSOR=false
+fi
+export INSTALL_CURSOR
+
+###############################################################################
 # PROMPT: Password
 ###############################################################################
 chapter "Caching password…"
@@ -106,8 +116,10 @@ source ./scripts/zsh_setup.sh
 ###############################################################################
 # SETUP: Cursor
 ###############################################################################
-chapter "Setting up Cursor…"
-source ./scripts/cursor_setup.sh
+if [ "$INSTALL_CURSOR" = "true" ]; then
+  chapter "Setting up Cursor…"
+  source ./scripts/cursor_setup.sh
+fi
 
 ###############################################################################
 # SETUP: Git


### PR DESCRIPTION
## Summary
- allow skipping Cursor IDE install in setup
- respect choice in Homebrew install

## Testing
- `bash -n setup.sh`
- `bash -n scripts/brew.sh`


------
https://chatgpt.com/codex/tasks/task_e_688be52d93c883249f97aa68a08d5e3d